### PR TITLE
Add charts/components helpers

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -115,25 +115,28 @@
       <div id="chart-2"></div>
 
       <script type="text/javascript">
+        var d3c = d3.compose;
         var chart = d3.select('#chart-2')
           .chart('Compose', function(data) {
             var scales = {
               x: {domain: [2000, 2020]},
               y: {data: data.lines, key: 'y'}
             };
+            var charts = [
+              d3c.lines('line', {data: data.lines, xScale: scales.x, yScale: scales.y, labels: {type: 'HoverLabels', hoverTolerance: 50}})
+            ];
+            var default_margins = {top: 8, right: 8, bottom: 8, left: 8};
 
             return [
-              {type: 'Title', text: 'Results by Year', 'class': 'chart-title-main'},
+              d3c.title({text: 'Results by Year', 'class': 'chart-title-main', margins: default_margins}),
               [
-                {type: 'Title', text: 'Results'},
-                {type: 'Axis', scale: scales.y},
-                d3.compose.layered([
-                  {id: 'line', type: 'Lines', data: data.lines, xScale: scales.x, yScale: scales.y, labels: {type: 'HoverLabels', hoverTolerance: 50}}
-                ]),
-                {type: 'Legend', charts: ['line']}
+                d3c.title({text: 'Results', margins: utils.defaults({right: 4}, default_margins)}),
+                d3c.axis('yAxis', {scale: scales.y}),
+                d3c.layered(charts),
+                d3c.legend({charts: ['line'], margins: default_margins})
               ],
-              {type: 'Axis', scale: scales.x, tickFormat: d3.format('####')},
-              {type: 'Title', text: 'Year'}
+              d3c.axis('xAxis', {scale: scales.x, tickFormat: d3.format('####')}),
+              d3c.title({text: 'Year', margins: utils.defaults({bottom: 4}, default_margins)})
             ];
           })
           .width(600)

--- a/src/charts/Bars.js
+++ b/src/charts/Bars.js
@@ -169,6 +169,15 @@
     }
   ));
 
+  d3.compose.bars = function(id, options) {
+    if (!options) {
+      options = id;
+      id = undefined;
+    }
+      
+    return utils.extend({id: id, type: 'Bars'}, options);
+  };
+
   /**
     Bars chart with values stacked on top of each other
 
@@ -235,6 +244,15 @@
       return new_position;
     })
   });
+
+  d3.compose.stackedBars = function(id, options) {
+    if (!options) {
+      options = id;
+      id = undefined;
+    }
+      
+    return utils.extend({id: id, type: 'StackedBars'}, options);
+  };
 
   /**
     Bars chart with bars that group from left-to-right
@@ -326,6 +344,15 @@
     },
   }));
 
+  d3.compose.horizontalBars = function(id, options) {
+    if (!options) {
+      options = id;
+      id = undefined;
+    }
+      
+    return utils.extend({id: id, type: 'HorizontalBars'}, options);
+  };
+
   /**
     Horizontal Stacked Bars
 
@@ -392,5 +419,14 @@
       return previous;
     })
   });
+
+  d3.compose.horizontalStackedBars = function(id, options) {
+    if (!options) {
+      options = id;
+      id = undefined;
+    }
+      
+    return utils.extend({id: id, type: 'HorizontalStackedBars'}, options);
+  };
 
 })(d3, d3.compose.helpers, d3.compose.mixins, d3.compose.charts);

--- a/src/charts/Labels.js
+++ b/src/charts/Labels.js
@@ -506,6 +506,15 @@
     z_index: 150
   });
 
+  d3.compose.labels = function(id, options) {
+    if (!options) {
+      options = id;
+      id = undefined;
+    }
+
+    return utils.extend({id: id, type: 'Labels'}, options);
+  };
+
   /**
     (in-progress)
 
@@ -563,5 +572,14 @@
       return label;
     }
   }));
+
+  d3.compose.hoverLabels = function(id, options) {
+    if (!options) {
+      options = id;
+      id = undefined;
+    }
+
+    return utils.extend({id: id, type: 'HoverLabels'}, options);
+  };
 
 })(d3, d3.compose.helpers, d3.compose.mixins, d3.compose.charts);

--- a/src/charts/Lines.js
+++ b/src/charts/Lines.js
@@ -139,4 +139,13 @@
     }
   ));
 
+  d3.compose.lines = function(id, options) {
+    if (!options) {
+      options = id;
+      id = undefined;
+    }
+
+    return utils.extend({id: id, type: 'Lines'}, options);
+  };
+
 })(d3, d3.compose.helpers, d3.compose.mixins, d3.compose.charts);

--- a/src/components/Axis.js
+++ b/src/components/Axis.js
@@ -402,4 +402,13 @@
     z_index: 60
   });
 
+  d3.compose.axis = function(id, options) {
+    if (!options) {
+      options = id;
+      id = undefined;
+    }
+
+    return utils.extend({id: id, type: 'Axis'}, options);
+  };
+
 })(d3, d3.compose.helpers, d3.compose.mixins, d3.compose.charts);

--- a/src/components/Legend.js
+++ b/src/components/Legend.js
@@ -300,6 +300,15 @@
       .attr('class', 'chart-bar');
   });
 
+  d3.compose.legend = function(id, options) {
+    if (!options) {
+      options = id;
+      id = undefined;
+    }
+
+    return utils.extend({id: id, type: 'Legend'}, options);
+  };
+
   /**
     Legend positioned within chart bounds.
 
@@ -366,5 +375,14 @@
   }, {
     layer_type: 'chart'
   });
+
+  d3.compose.insetLegend = function(id, options) {
+    if (!options) {
+      options = id;
+      id = undefined;
+    }
+
+    return utils.extend({id: id, type: 'InsetLegend'}, options);
+  };
 
 })(d3, d3.compose.helpers, d3.compose.mixins, d3.compose.charts);

--- a/src/components/Title.js
+++ b/src/components/Title.js
@@ -178,4 +178,15 @@
     z_index: 70
   });
 
+  d3.compose.title = function(id, options) {
+    if (!options) {
+      options = id;
+      id = undefined;
+    }
+    if (utils.isString(options))
+      options = {text: options};
+
+    return utils.extend({id: id, type: 'Title'}, options);
+  };
+
 })(d3, d3.compose.helpers, d3.compose.mixins, d3.compose.charts);

--- a/src/extensions/xy.js
+++ b/src/extensions/xy.js
@@ -8,8 +8,9 @@
     @class extensions
   */
 
+  // TODO Integrate xy defaults (e.g. margins) into standard charts/components
   /**
-    XY extension
+    XY extension (DEPRECATED)
     Generate d3.compose options for XY charts
   
     @example


### PR DESCRIPTION
Phase 2 of #24 

Add helpers for standard charts/components for a little cleaner options and opportunity for future additions/changes.

Example:

``` js
var d3c = d3.compose;

d3.select('#chart').chart('Compose', function(data) {
  var scales = {
    x: {/* ... */},
    y: {/* ... */}
  };

  return [
    d3c.title({text: 'Main Title', 'class': 'chart-title-main'}),
    [
      d3c.title('y-axis'),
      d3c.axis('yAxis', {scale: scales.y}),
      d3c.layered(
        d3c.lines('lines', {data: data, xScale: scales.x, yScale: scales.y})
      )
    ],
    d3c.axis('xAxis', {scale: scales.x}),
    d3c.title('x-axis')
  ]
});
```

If `(String, ...)` is given, first parameter to helpers is an optional id (needed if components are moving within layout or layout "shape" is changing), otherwise first parameter is `options`. (Note: `title` is overloaded to accept `String` or `Object` for options)
