### PR TITLE
Simplify and refactor property

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -290,7 +290,9 @@
             ];
           })
           .width(600)
-          .height(400);
+          .height(400)
+          .duration(1000)
+          .delay(200);
 
         chart.draw(data['chart-3']);
       </script>

--- a/specs/Base.spec.js
+++ b/specs/Base.spec.js
@@ -5,7 +5,7 @@
 
     it('should set properties from options', function() {
       var HasProperties = Base.extend('HasProperties', {
-        a: helpers.property('a')
+        a: helpers.property()
       });
       var base = new HasProperties();
       base.options({a: 123, b: 456});
@@ -16,8 +16,8 @@
 
     it('should clear existing properties for new options', function() {
       var HasProperties = Base.extend('HasProperties', {
-        a: helpers.property('a'),
-        b: helpers.property('b')
+        a: helpers.property(),
+        b: helpers.property()
       });
       var base = new HasProperties();
       base.options({a: 123, b: 456});

--- a/specs/Compose.spec.js
+++ b/specs/Compose.spec.js
@@ -15,10 +15,10 @@
       container.margins(0);
 
       Chart = d3.chart('Chart').extend('TestChart', {
-        name: helpers.property('name')
+        name: helpers.property()
       });
       Component = d3.chart('Component').extend('TestComponent', {
-        name: helpers.property('name')
+        name: helpers.property()
       });
     });
 

--- a/specs/helpers.spec.js
+++ b/specs/helpers.spec.js
@@ -10,7 +10,7 @@
       });
 
       it('should get and set value', function() {
-        instance.message = property('message');
+        instance.message = property();
 
         expect(instance.message()).toBeUndefined();
         instance.message('Hello');
@@ -18,7 +18,7 @@
       });
 
       it('should use default values', function() {
-        instance.message = property('message', {
+        instance.message = property({
           default_value: 'Howdy!'
         });
 
@@ -32,7 +32,7 @@
       });
 
       it('should expose default_value on property', function() {
-        instance.message = property('message', {
+        instance.message = property({
           default_value: 'Howdy!'
         });
 
@@ -41,39 +41,15 @@
         expect(instance.message()).toEqual('Goodbye!');
       });
 
-      it('should evaluate get if type is not function', function() {
-        instance.message = property('message');
-
-        instance.message(function() { return 'Howdy!'; });
-        expect(instance.message()).toEqual('Howdy!');
-
-        instance.message = property('message', {type: 'Function'});
-        instance.message(function() { return 'Howdy!'; });
-        expect(typeof instance.message()).toEqual('function');
-        expect(instance.message()()).toEqual('Howdy!');
-      });
-
-      it('should evaluate get with context of object', function() {
-        instance.message = property('message');
-        instance.message(function() { return 'Howdy from ' + this.name; });
-        expect(instance.message()).toEqual('Howdy from Chart');
-      });
-
-      it('should store set values on object at prop_key', function() {
-        instance.message = property('message', {prop_key: 'properties'});
-        instance.message('Howdy!');
-        expect(instance.properties.message).toEqual('Howdy!');
-      });
-
       it('should expose is_property and set_from_options on property', function() {
-        instance.message = property('message', {set_from_options: false});
+        instance.message = property({set_from_options: false});
         expect(instance.message.is_property).toEqual(true);
         expect(instance.message.set_from_options).toEqual(false);
       });
 
       describe('get()', function() {
         it('should be used for return value', function() {
-          instance.message = property('message', {
+          instance.message = property({
             get: function(value) {
               return value + '!';
             }
@@ -84,7 +60,7 @@
         });
 
         it('should use context of object by default', function() {
-          instance.message = property('message', {
+          instance.message = property({
             get: function(value) {
               return value + ' from ' + this.name + '!';
             }
@@ -95,7 +71,7 @@
         });
 
         it('should use context if set', function() {
-          instance.message = property('message', {
+          instance.message = property({
             get: function(value) {
               return value + ' from ' + this.name + '!';
             },
@@ -110,7 +86,7 @@
       describe('set()', function() {
         it('should pass previous to set', function() {
           var args;
-          instance.message = property('message', {
+          instance.message = property({
             set: function(value, previous) {
               args = [value, previous];
             }
@@ -123,7 +99,7 @@
         });
 
         it('should override set', function() {
-          instance.message = property('message', {
+          instance.message = property({
             set: function(value) {
               if (value === 'Hate')
                 return {override: 'Love'};
@@ -137,7 +113,7 @@
         });
 
         it('should use undefined value in override on set', function() {
-          instance.message = property('message', {
+          instance.message = property({
             set: function(value) {
               if (value == 'Unknown')
                 return {override: undefined};
@@ -155,7 +131,7 @@
           function getValue() {
             return instance.message();
           }
-          instance.message = property('message', {
+          instance.message = property({
             set: function() {
               before = getValue();
               return {
@@ -173,7 +149,7 @@
         });
 
         it('should use context of object by default', function() {
-          instance.message = property('message', {
+          instance.message = property({
             set: function(value) {
               return {
                 override: value + ' from ' + this.name + '!'
@@ -186,7 +162,7 @@
         });
 
         it('should use context if set', function() {
-          instance.message = property('message', {
+          instance.message = property({
             set: function(value) {
               return {
                 override: value + ' from ' + this.name + '!'
@@ -201,7 +177,7 @@
 
         describe('validate', function() {
           beforeEach(function() {
-            instance.message = property('message', {
+            instance.message = property({
               validate: function(value) {
                 return value != 'INVALID';
               }

--- a/src/Base.js
+++ b/src/Base.js
@@ -39,7 +39,7 @@ export default d3.chart('Base', {
     @property data
     @type Any
   */
-  data: property('data'),
+  data: property(),
 
   /**
     Overall options for chart/component, automatically setting any matching properties.
@@ -49,8 +49,8 @@ export default d3.chart('Base', {
     var property = d3.compose.helpers.property;
 
     d3.chart('Base').extend('HasProperties', {
-      a: property('a'),
-      b: property('b', {
+      a: property(),
+      b: property({
         set: function(value) {
           return {
             override: value + '!'
@@ -78,7 +78,7 @@ export default d3.chart('Base', {
     @property options
     @type Object
   */
-  options: property('options', {
+  options: property({
     default_value: {},
     set: function(options, previous) {
       // Clear all unset options, except for data and options

--- a/src/Chart.js
+++ b/src/Chart.js
@@ -26,7 +26,7 @@ import Base from './Base';
       // "di" function with parent chart injected ("this" = element)
     }),
 
-    centered: helpers.property('centered', {
+    centered: helpers.property({
       default_value: true
       // can be automatically set from options object
     })

--- a/src/Component.js
+++ b/src/Component.js
@@ -55,7 +55,7 @@ export default Base.extend('Component', {
     @type String
     @default 'top'
   */
-  position: property('position', {
+  position: property({
     default_value: 'top',
     validate: function(value) {
       return contains(['top', 'right', 'bottom', 'left'], value);
@@ -70,7 +70,7 @@ export default Base.extend('Component', {
     @type Number
     @default (actual width)
   */
-  width: property('width', {
+  width: property({
     default_value: function() {
       return dimensions(this.base).width;
     }
@@ -84,7 +84,7 @@ export default Base.extend('Component', {
     @type Number
     @default (actual height)
   */
-  height: property('height', {
+  height: property({
     default_value: function() {
       return dimensions(this.base).height;
     }
@@ -97,7 +97,7 @@ export default Base.extend('Component', {
     @type Object
     @default {top: 0, right: 0, bottom: 0, left: 0}
   */
-  margins: property('margins', {
+  margins: property({
     set: function(values) {
       return {
         override: getMargins(values)
@@ -113,7 +113,7 @@ export default Base.extend('Component', {
     @type Boolean
     @default false
   */
-  centered: property('centered', {
+  centered: property({
     default_value: false
   }),
 

--- a/src/Compose.js
+++ b/src/Compose.js
@@ -125,9 +125,8 @@ export default Base.extend('Compose', {
     @property options
     @type Function|Object
   */
-  options: property('options', {
-    default_value: function() {},
-    type: 'Function',
+  options: property({
+    default_value: function() { return function() {}; },
     set: function(options) {
       // If options is plain object,
       // return from generic options function
@@ -142,7 +141,7 @@ export default Base.extend('Compose', {
   }),
 
   // Store raw data for container before it has been transformed
-  rawData: property('rawData'),
+  rawData: property(),
 
   /**
     Margins between edge of container and components/chart
@@ -155,7 +154,7 @@ export default Base.extend('Compose', {
     @type Object {top, right, bottom, left}
     @default {top: 10, right: 10, bottom: 10, left: 10}
   */
-  margins: property('margins', {
+  margins: property({
     default_value: default_compose_margins,
     set: function(values) {
       return {
@@ -165,7 +164,7 @@ export default Base.extend('Compose', {
   }),
 
   // Chart position
-  chartPosition: property('chartPosition', {
+  chartPosition: property({
     default_value: {top: 0, right: 0, bottom: 0, left: 0},
     set: function(values) {
       return {
@@ -186,7 +185,7 @@ export default Base.extend('Compose', {
     @property width
     @type Number
   */
-  width: property('width', {
+  width: property({
     default_value: null
   }),
 
@@ -196,7 +195,7 @@ export default Base.extend('Compose', {
     @property height
     @type Number
   */
-  height: property('height', {
+  height: property({
     default_value: null
   }),
 
@@ -217,12 +216,12 @@ export default Base.extend('Compose', {
     @type Boolean
     @default true
   */
-  responsive: property('responsive', {
+  responsive: property({
     default_value: true
   }),
 
   // Set svg viewBox attribute
-  viewBox: property('viewBox', {
+  viewBox: property({
     default_value: function() {
       if (this.responsive() && this.width() && this.height())
         return '0 0 ' + this.width() + ' ' + this.height();
@@ -232,7 +231,7 @@ export default Base.extend('Compose', {
   }),
 
   // Set svg preserveAspectRatio attribute
-  preserveAspectRatio: property('preserveAspectRatio', {
+  preserveAspectRatio: property({
     default_value: function() {
       if (this.responsive())
         return 'xMidYMid meet';
@@ -242,7 +241,7 @@ export default Base.extend('Compose', {
   }),
 
   // Set container style
-  containerStyle: property('containerStyle', {
+  containerStyle: property({
     default_value: function() {
       if (this.responsive()) {
         var aspect_ratio = 1;
@@ -263,7 +262,7 @@ export default Base.extend('Compose', {
   }),
 
   // Set base style
-  baseStyle: property('baseStyle', {
+  baseStyle: property({
     default_value: function() {
       if (this.responsive() && this.container) {
         return style({
@@ -294,7 +293,7 @@ export default Base.extend('Compose', {
     @property charts
     @type Array
   */
-  charts: property('charts', {
+  charts: property({
     set: function(chart_options, charts) {
       // Store actual charts rather than options
       return {
@@ -320,7 +319,7 @@ export default Base.extend('Compose', {
     @property components
     @type Array
   */
-  components: property('components', {
+  components: property({
     set: function(component_options, components) {
       // Store actual components rather than options
       return {
@@ -338,7 +337,7 @@ export default Base.extend('Compose', {
     @type Number|Function
     @default d3 default: 0
   */
-  delay: property('delay', {type: 'Function'}),
+  delay: property(),
 
   /**
     Transition duration in milliseconds.
@@ -348,7 +347,7 @@ export default Base.extend('Compose', {
     @type Number|Function
     @default d3 default: 250ms
   */
-  duration: property('duration', {type: 'Function'}),
+  duration: property(),
 
   /**
     Transition ease function.
@@ -361,7 +360,7 @@ export default Base.extend('Compose', {
     @type String|Function
     @default d3 default: 'cubic-in-out'
   */
-  ease: property('ease', {type: 'Function'}),
+  ease: property(),
 
   /**
     Draw chart with given data

--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -38,7 +38,7 @@ export default Component.extend('Overlay', {
     @type Number
     @default 0
   */
-  x: property('x', {
+  x: property({
     default_value: 0
   }),
 
@@ -49,7 +49,7 @@ export default Component.extend('Overlay', {
     @type Number
     @default 0
   */
-  y: property('y', {
+  y: property({
     default_value: 0
   }),
 
@@ -60,7 +60,7 @@ export default Component.extend('Overlay', {
     @type Boolean
     @default true
   */
-  hidden: property('hidden', {
+  hidden: property({
     default_value: true
   }),
 
@@ -72,7 +72,7 @@ export default Component.extend('Overlay', {
     @type String
     @default set from x, y, and hidden
   */
-  style: property('style', {
+  style: property({
     default_value: function() {
       var styles = {
         position: 'absolute',

--- a/src/charts/HoverLabels.js
+++ b/src/charts/HoverLabels.js
@@ -28,7 +28,7 @@ var HoverLabels = Labels.extend('HoverLabels', mixin(Hover, {
     @type Number
     @default Infinity
   */
-  hoverTolerance: property('hoverTolerance', {
+  hoverTolerance: property({
     set: function(value) {
       // Pass through hover tolerance to parent (if present)
       if (this.parent && this.parent.hoverTolerance)

--- a/src/charts/Labels.js
+++ b/src/charts/Labels.js
@@ -138,8 +138,7 @@ var Labels = Chart.extend('Labels', mixin(
       @property format
       @type String|Function
     */
-    format: property('format', {
-      type: 'Function',
+    format: property({
       set: function(value) {
         if (isString(value)) {
           return {
@@ -157,7 +156,7 @@ var Labels = Chart.extend('Labels', mixin(
       @type String
       @default top
     */
-    position: property('position', {
+    position: property({
       default_value: 'top',
       validate: function(value) {
         return contains(['top', 'right', 'bottom', 'left'], value);
@@ -172,7 +171,7 @@ var Labels = Chart.extend('Labels', mixin(
       @type Number|Object
       @default {x: 0, y: 0}
     */
-    offset: property('offset', {
+    offset: property({
       default_value: {x: 0, y: 0},
       set: function(offset) {
         if (isNumber(offset)) {
@@ -200,7 +199,7 @@ var Labels = Chart.extend('Labels', mixin(
       @type Number
       @default 1
     */
-    padding: property('padding', {default_value: 1}),
+    padding: property({default_value: 1}),
 
     /**
       Define text anchor (start, middle, or end)
@@ -211,7 +210,7 @@ var Labels = Chart.extend('Labels', mixin(
       @type String
       @default middle
     */
-    anchor: property('anchor', {
+    anchor: property({
       default_value: function() {
         return {
           'top': 'middle',
@@ -234,7 +233,7 @@ var Labels = Chart.extend('Labels', mixin(
       @type String
       @default middle
     */
-    alignment: property('alignment', {
+    alignment: property({
       default_value: function() {
         return {
           'top': 'bottom',

--- a/src/charts/Lines.js
+++ b/src/charts/Lines.js
@@ -97,7 +97,7 @@ var Lines = Chart.extend('Lines', mixin(
       @type String
       @default monotone
     */
-    interpolate: property('interpolate', {
+    interpolate: property({
       default_value: 'monotone'
     }),
 

--- a/src/components/Axis.js
+++ b/src/components/Axis.js
@@ -167,8 +167,7 @@ var Axis = Component.extend('Axis', mixin(XY, Transition, StandardLayer, {
     @property scale
     @type Object|d3.scale
   */
-  scale: property('scale', {
-    type: 'Function',
+  scale: property({
     set: function(value, previous) {
       this.previous = this.previous || {};
       this.previous.scale = previous;
@@ -198,7 +197,7 @@ var Axis = Component.extend('Axis', mixin(XY, Transition, StandardLayer, {
     @type String
     @default bottom
   */
-  position: property('position', {
+  position: property({
     default_value: 'bottom',
     validate: function(value) {
       return contains(['top', 'right', 'bottom', 'left'], value);
@@ -218,7 +217,7 @@ var Axis = Component.extend('Axis', mixin(XY, Transition, StandardLayer, {
     @type Object
     @default (set based on position)
   */
-  translation: property('translation', {
+  translation: property({
     default_value: function() {
       switch (this.position()) {
         case 'top':
@@ -248,7 +247,7 @@ var Axis = Component.extend('Axis', mixin(XY, Transition, StandardLayer, {
     @type String
     @default (set based on position)
   */
-  orient: property('orient', {
+  orient: property({
     default_value: function() {
       var orient = this.position();
 
@@ -268,7 +267,7 @@ var Axis = Component.extend('Axis', mixin(XY, Transition, StandardLayer, {
     @type String
     @default (set based on position)
   */
-  orientation: property('orientation', {
+  orientation: property({
     validate: function(value) {
       return contains(['horizontal', 'vertical'], value);
     },
@@ -297,7 +296,7 @@ var Axis = Component.extend('Axis', mixin(XY, Transition, StandardLayer, {
     @type Boolean|Object
     @default false
   */
-  gridlines: property('gridlines', {
+  gridlines: property({
     get: function(value) {
       if (isBoolean(value))
         value = {display: value};
@@ -309,17 +308,16 @@ var Axis = Component.extend('Axis', mixin(XY, Transition, StandardLayer, {
   }),
 
   // d3.axis extensions
-  ticks: property('ticks', {type: 'Function'}),
-  tickValues: property('tickValues', {type: 'Function'}),
-  tickSize: property('tickSize', {type: 'Function'}),
-  innerTickSize: property('innerTickSize', {type: 'Function'}),
-  outerTickSize: property('outerTickSize', {type: 'Function'}),
-  tickPadding: property('tickPadding', {type: 'Function'}),
-  tickFormat: property('tickFormat', {type: 'Function'}),
+  ticks: property(),
+  tickValues: property(),
+  tickSize: property(),
+  innerTickSize: property(),
+  outerTickSize: property(),
+  tickPadding: property(),
+  tickFormat: property(),
 
   // Store previous value for xScale, yScale, and duration
-  xScale: property('xScale', {
-    type: 'Function',
+  xScale: property({
     set: function(value, previous) {
       this.previous = this.previous || {};
       this.previous.xScale = previous;
@@ -331,8 +329,7 @@ var Axis = Component.extend('Axis', mixin(XY, Transition, StandardLayer, {
     }
   }),
 
-  yScale: property('yScale', {
-    type: 'Function',
+  yScale: property({
     set: function(value, previous) {
       this.previous = this.previous || {};
       this.previous.yScale = previous;
@@ -344,7 +341,7 @@ var Axis = Component.extend('Axis', mixin(XY, Transition, StandardLayer, {
     }
   }),
 
-  duration: property('duration', {
+  duration: property({
     set: function(value, previous) {
       this.previous = this.previous || {};
       this.previous.duration = previous;

--- a/src/components/AxisTitle.js
+++ b/src/components/AxisTitle.js
@@ -25,7 +25,7 @@ var AxisTitle = Title.extend('AxisTitle', {
     @type Object
     @default (set based on `position`)
   */
-  margins: property('margins', {
+  margins: property({
     set: function(values) {
       return {
         override: getMargins(values, defaultMargins(this.position()))

--- a/src/components/Gridlines.js
+++ b/src/components/Gridlines.js
@@ -84,7 +84,7 @@ var Gridlines = Component.extend('Gridlines', mixin(XY, Transition, StandardLaye
     @type String
     @default horizontal
   */
-  orientation: property('orientation', {
+  orientation: property({
     default_value: 'horizontal',
     validate: function(value) {
       return contains(['horizontal', 'vertical'], value);
@@ -111,8 +111,7 @@ var Gridlines = Component.extend('Gridlines', mixin(XY, Transition, StandardLaye
     @property scale
     @type Object|d3.scale
   */
-  scale: property('scale', {
-    type: 'Function',
+  scale: property({
     set: function(value) {
       if (this.orientation() == 'vertical') {
         this.xScale(value);
@@ -130,11 +129,10 @@ var Gridlines = Component.extend('Gridlines', mixin(XY, Transition, StandardLaye
   }),
 
   // d3.axis extensions
-  ticks: property('ticks', {
-    type: 'Function',
+  ticks: property({
     default_value: [10]
   }),
-  tickValues: property('tickValues', {type: 'Function'}),
+  tickValues: property(),
 
   drawLine: di(function(chart, d) {
     var x1, x2, y1, y2;

--- a/src/components/InsetLegend.js
+++ b/src/components/InsetLegend.js
@@ -46,7 +46,7 @@ var InsetLegend = Legend.extend('InsetLegend', {
     @type Object {x,y}
     @default {x: 10, y: 10, relative_to: 'left-top'}
   */
-  translation: property('translation', {
+  translation: property({
     default_value: {x: 10, y: 0, relative_to: 'left-top'},
     get: function(value) {
       var x = value.x || 0;

--- a/src/components/Legend.js
+++ b/src/components/Legend.js
@@ -124,7 +124,7 @@ var Legend = Component.extend('Legend', mixin(StandardLayer, {
     @property charts
     @type Array
   */
-  charts: property('charts'),
+  charts: property(),
 
   /**
     Dimensions of "swatch"
@@ -133,7 +133,7 @@ var Legend = Component.extend('Legend', mixin(StandardLayer, {
     @type Object
     @default {width: 20, height: 20}
   */
-  swatchDimensions: property('swatchDimensions', {
+  swatchDimensions: property({
     default_value: {width: 20, height: 20}
   }),
 
@@ -144,7 +144,7 @@ var Legend = Component.extend('Legend', mixin(StandardLayer, {
     @type Object
     @default {top: 8, right: 8, bottom: 8, left: 8}
   */
-  margins: property('margins', {
+  margins: property({
     default_value: default_legend_margins,
     set: function(values) {
       return {
@@ -161,7 +161,7 @@ var Legend = Component.extend('Legend', mixin(StandardLayer, {
     @type String
     @default (based on position)
   */
-  stackDirection: property('stackDirection', {
+  stackDirection: property({
     validate: function(value) {
       return contains(['vertical', 'horizontal'], value);
     },

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -69,7 +69,7 @@ var Text = Component.extend('Text', mixin(StandardLayer, {
     @property text
     @type String
   */
-  text: property('text'),
+  text: property(),
 
   /**
     Rotation of text
@@ -78,7 +78,7 @@ var Text = Component.extend('Text', mixin(StandardLayer, {
     @type Number
     @default 0
   */
-  rotation: property('rotation', {
+  rotation: property({
     default_value: 0
   }),
 
@@ -89,7 +89,7 @@ var Text = Component.extend('Text', mixin(StandardLayer, {
     @type String
     @default "center"
   */
-  textAlign: property('textAlign', {
+  textAlign: property({
     default_value: 'center',
     validate: function(value) {
       return contains(['left', 'center', 'right'], value);
@@ -103,7 +103,7 @@ var Text = Component.extend('Text', mixin(StandardLayer, {
     @type String
     @default (set by `textAlign`)
   */
-  anchor: property('anchor', {
+  anchor: property({
     default_value: function() {
       return {
         left: 'start',
@@ -123,7 +123,7 @@ var Text = Component.extend('Text', mixin(StandardLayer, {
     @type String
     @default "middle"
   */
-  verticalAlign: property('verticalAlign', {
+  verticalAlign: property({
     default_value: 'middle',
     validate: function(value) {
       return contains(['top', 'middle', 'bottom'], value);
@@ -137,7 +137,7 @@ var Text = Component.extend('Text', mixin(StandardLayer, {
     @type Object
     @default {}
   */
-  style: property('style', {
+  style: property({
     default_value: {},
     get: function(value) {
       return style(value) || null;

--- a/src/components/Title.js
+++ b/src/components/Title.js
@@ -22,7 +22,7 @@ var Title = Text.extend('Title', {
     @type Object
     @default (set based on `position`)
   */
-  margins: property('margins', {
+  margins: property({
     set: function(values) {
       return {
         override: getMargins(values, defaultMargins(this.position()))
@@ -40,7 +40,7 @@ var Title = Text.extend('Title', {
     @type Number
     @default (set based on `position`)
   */
-  rotation: property('rotation', {
+  rotation: property({
     default_value: function() {
       var rotate_by_position = {
         right: 90,

--- a/src/helpers/property.js
+++ b/src/helpers/property.js
@@ -3,6 +3,7 @@ import {
   isUndefined,
   valueOrDefault
 } from '../utils';
+var unique_index = 0;
 
 /**
   Helper for creating properties for charts/components
@@ -11,7 +12,7 @@ import {
   ```javascript
   var Custom = d3.chart('Chart').extend('Custom', {
     // Create property that's stored internally as 'simple'
-    simple: property('simple')
+    simple: property()
   });
   var custom; // = new Custom(...);
 
@@ -24,7 +25,7 @@ import {
   // Advanced
   // --------
   // Default values:
-  Custom.prototype.message = property('message', {
+  Custom.prototype.message = property({
     default_value: 'Howdy!'
   });
 
@@ -36,8 +37,26 @@ import {
   custom.message(undefined);
   console.log(custom.message()); // -> 'Howdy!'
 
+  // Computed default value:
+  Custom.property.computed = property({
+    default_value: function() {
+      // "this" = Custom instance
+      return this.message();
+    }
+  });
+
+  // Function default value:
+  // For function default_values, wrap in function to differentiate from computed
+  Custom.property.fn = property({
+    default_value: function() {
+      return function defaultFn() {};
+    }
+    // The following would be incorrectly evaluated
+    // default_value: function defaultFn() {}
+  })
+
   // Custom getter:
-  Custom.prototype.exclaimed = property('exclaimed', {
+  Custom.prototype.exclaimed = property({
     get: function(value) {
       // Value is the underlying set value
       return value + '!';
@@ -48,7 +67,7 @@ import {
   console.log(custom.exclaimed()); // -> 'Howdy!'
 
   // Custom setter:
-  Custom.prototype.feeling = property('feeling', {
+  Custom.prototype.feeling = property({
     set: function(value, previous) {
       if (value == 'Hate') {
         // To override value, return Object with override specified
@@ -69,22 +88,26 @@ import {
   ```
   @method property
   @for helpers
-  @param {String} name of stored property
   @param {Object} [options]
-  @param {Any} [options.default_value] default value for property (when set value is `undefined`)
+  @param {Any} [options.default_value] default value for property (when set value is `undefined`). If default value is a function, wrap in another function as default_value is evaluated by default.
   @param {Function} [options.get] `function(value) {return ...}` getter, where `value` is the stored value and return desired value
   @param {Function} [options.set] `function(value, previous) {return {override, after}}`. Return `override` to override stored value and `after()` to run after set
-  @param {String} [options.type] `get` is evaluated by default, use `"Function"` to skip evaluation
   @param {Object} [options.context=this] context to evaluate get/set/after functions
-  @param {String} [options.prop_key='__properties'] underlying key on object to store property
   @return {Function} `()`: get, `(value)`: set
 */
-export default function property(name, options) {
+export default function property(options) {
+  // DEPRECATED: name as first argument
+  if (arguments.length == 2) {
+    if (typeof console != 'undefined' && console.warn)
+      console.warn('DEPRECATED - name argument for property is no longer supported will be removed in the next version of d3.compose');
+    options = arguments[1];
+  }
+
   options = options || {};
-  var prop_key = options.prop_key || '__properties';
+  var id = 'property_' + unique_index++;
 
   var property = function(value) {//eslint-disable-line no-shadow
-    var properties = this[prop_key] = this[prop_key] || {};
+    var properties = this.__properties = this.__properties || {};
     var context = valueOrDefault(property.context, this);
 
     if (arguments.length)
@@ -93,30 +116,33 @@ export default function property(name, options) {
       return get.call(this);
 
     function get() {
-      value = valueOrDefault(properties[name], property.default_value);
+      value = properties[id];
 
-      // Unwrap value if its type is not a function
-      if (isFunction(value) && options.type != 'Function')
-        value = value.call(this);
+      if (isUndefined(value)) {
+        // Use default value and unwrap if it's a function
+        value = property.default_value;
+        if (isFunction(value))
+          value = value.call(context);
+      }
 
       return isFunction(options.get) ? options.get.call(context, value) : value;
     }
 
     function set() {
       // Validate
-      if (isFunction(options.validate) && !isUndefined(value) && !options.validate.call(this, value))
-        throw new Error('Invalid value for ' + name + ': ' + JSON.stringify(value));
+      if (isFunction(options.validate) && !isUndefined(value) && !options.validate.call(context, value))
+        throw new Error('Invalid value for property: ' + JSON.stringify(value));
 
-      var previous = properties[name];
-      properties[name] = value;
+      var previous = properties[id];
+      properties[id] = value;
 
       if (isFunction(options.set) && !isUndefined(value)) {
         var response = options.set.call(context, value, previous);
 
         if (response && 'override' in response)
-          properties[name] = response.override;
+          properties[id] = response.override;
         if (response && isFunction(response.after))
-          response.after.call(context, properties[name]);
+          response.after.call(context, properties[id]);
       }
 
       return this;
@@ -125,6 +151,7 @@ export default function property(name, options) {
 
   // For checking if function is a property
   property.is_property = true;
+  property.id = id;
   property.set_from_options = valueOrDefault(options.set_from_options, true);
   property.default_value = options.default_value;
   property.context = options.context;

--- a/src/mixins/hover.js
+++ b/src/mixins/hover.js
@@ -188,7 +188,7 @@ var HoverPoints = {
     @type Number
     @default Infinity
   */
-  hoverTolerance: property('hoverTolerance', {
+  hoverTolerance: property({
     default_value: Infinity
   })
 };

--- a/src/mixins/labels.js
+++ b/src/mixins/labels.js
@@ -82,7 +82,7 @@ var Labels = {
     @property labels
     @type Object
   */
-  labels: property('labels', {
+  labels: property({
     get: function(value) {
       if (isBoolean(value))
         value = {display: value};

--- a/src/mixins/transition.js
+++ b/src/mixins/transition.js
@@ -19,14 +19,7 @@ var Transition = {
     @type Number|Function
     @default (use container value, if available)
   */
-  delay: property('delay', {
-    set: function(value) {
-      // type: 'Function' is desired, but default_value needs to be evaluated
-      // wrap value in function
-      return {
-        override: function() { return value; }
-      };
-    },
+  delay: property({
     default_value: function() {
       return this.container && this.container.delay && this.container.delay();
     }
@@ -39,12 +32,7 @@ var Transition = {
     @type Number|Function
     @default (use container value, if available)
   */
-  duration: property('duration', {
-    set: function(value) {
-      return {
-        override: function() { return value; }
-      };
-    },
+  duration: property({
     default_value: function() {
       return this.container && this.container.delay && this.container.duration();
     }
@@ -60,12 +48,7 @@ var Transition = {
     @type String|Function
     @default (use container value, if available)
   */
-  ease: property('ease', {
-    set: function(value) {
-      return {
-        override: function() { return value; }
-      };
-    },
+  ease: property({
     default_value: function() {
       return this.container && this.container.delay && this.container.ease();
     }

--- a/src/mixins/xy.js
+++ b/src/mixins/xy.js
@@ -56,8 +56,7 @@ var XY = {
     @property xScale
     @type Object|d3.scale
   */
-  xScale: property('xScale', {
-    type: 'Function',
+  xScale: property({
     set: function(value) {
       var scale = createScale(value);
       this.setXScaleRange(scale);
@@ -82,8 +81,7 @@ var XY = {
     @property xScale
     @type Object|d3.scale
   */
-  yScale: property('yScale', {
-    type: 'Function',
+  yScale: property({
     set: function(value) {
       var scale = createScale(value);
       this.setYScaleRange(scale);
@@ -109,7 +107,7 @@ var XY = {
     @type String
     @default 'x'
   */
-  xKey: property('xKey', {
+  xKey: property({
     default_value: 'x'
   }),
 
@@ -120,7 +118,7 @@ var XY = {
     @type String
     @default 'y'
   */
-  yKey: property('yKey', {
+  yKey: property({
     default_value: 'y'
   }),
 


### PR DESCRIPTION
Previously, `name` was required as key to store property on internal `__properties` object and ended up being added boilerplate for every property that repeated the prototype key. Since this functionality is internal, the name isn't exposed and a unique id can be used instead which can then be used to determine the `name`, if necessary. To account for functions as `default_value`, `type: 'Function'` has been added, but it could affect directly set values. Instead, `type` has been removed, `default_value` is always evaluated if it's a function, and functions as `default_value` should be wrapped in a function. Finally `prop_key` is no longer available (`__properties` is always used).

Before:

``` js
a: property('a', {
  default_value: function defaultFn() {},
  type: 'Function'
}),
b: property('b')
```

After:

``` js
a: property({
  default_value: function() { return defaultFn() {} }
}),
b: property()
```

Changes:
- `name`: deprecated and will be removed in next version
- `type`: removed, must wrap function default_value
- `prop_key`: removed, always `__properties`
