### PR TITLE
Update extend and mixin behavior

### DIFF
--- a/specs/Base.spec.js
+++ b/specs/Base.spec.js
@@ -4,7 +4,7 @@
     var Base = d3.chart('Base');
 
     it('should set properties from options', function() {
-      var HasProperties = Base.extend('HasProperties', {
+      var HasProperties = Base.extend({
         a: helpers.property()
       });
       var base = new HasProperties();
@@ -15,7 +15,7 @@
     });
 
     it('should clear existing properties for new options', function() {
-      var HasProperties = Base.extend('HasProperties', {
+      var HasProperties = Base.extend({
         a: helpers.property(),
         b: helpers.property()
       });
@@ -32,7 +32,7 @@
     });
 
     it('should store fully-transformed data', function() {
-      var A = Base.extend('A', {
+      var A = Base.extend({
         transform: function(data) {
           return data.map(function(value) {
             value += 10;
@@ -40,8 +40,9 @@
           });
         }
       });
-      var B = A.extend('B', {
+      var B = A.extend({
         transform: function(data) {
+          data = A.prototype.transform.call(this, data);
           return data.map(function(value) {
             value += 20;
             return value;

--- a/specs/Compose.spec.js
+++ b/specs/Compose.spec.js
@@ -9,7 +9,7 @@
       setFixtures('<div id="chart"></div>');
       selection = d3.select('#chart');
 
-      Container = d3.chart('Compose').extend('TestContainer');
+      Container = d3.chart('Compose').extend();
       container = new Container(selection);
       container.responsive(false);
       container.margins(0);

--- a/specs/mixins.spec.js
+++ b/specs/mixins.spec.js
@@ -29,7 +29,7 @@
       width = 600;
       height = 400;
 
-      Chart = d3.chart('Chart').extend('Series', helpers.mixin(mixins.Series, {
+      Chart = helpers.mixin(d3.chart('Chart'), mixins.Series).extend('Series', {
         initialize: function() {
           this._layers = {
             mock: {
@@ -48,7 +48,7 @@
         width: function() {
           return width;
         }
-      }));
+      });
     });
 
     describe('Series', function() {

--- a/src/Chart.js
+++ b/src/Chart.js
@@ -35,7 +35,7 @@ import Base from './Base';
   @class Chart
   @extends Base
 */
-export default Base.extend('Chart', {}, {
+var Chart = Base.extend({}, {
   /**
     Default z-index for chart
     (Components are 50 by default, so Chart = 100 is above component by default)
@@ -56,3 +56,6 @@ export default Base.extend('Chart', {}, {
   z_index: 100,
   layer_type: 'chart'
 });
+
+d3.chart().Chart = Chart;
+export default Chart;

--- a/src/Component.js
+++ b/src/Component.js
@@ -46,7 +46,7 @@ import Base from './Base';
   @class Component
   @extends Base
 */
-export default Base.extend('Component', {
+var Component = Base.extend({
   /**
     Component's position relative to chart
     (top, right, bottom, left)
@@ -278,3 +278,6 @@ export default Base.extend('Component', {
   */
   layer_type: 'component'
 });
+
+d3.chart().Component = Component;
+export default Component;

--- a/src/Compose.js
+++ b/src/Compose.js
@@ -62,15 +62,9 @@ var default_compose_margins = {top: 10, right: 10, bottom: 10, left: 10};
   @class Compose
   @extends Base
 */
-export default Base.extend('Compose', {
-  initialize: function() {
-    // Overriding transform in init jumps it to the top of the transform cascade
-    // Therefore, data coming in hasn't been transformed and is raw
-    // (Save raw data for redraw)
-    this.transform = function(data) {
-      this.rawData(data);
-      return data;
-    };
+var Compose = Base.extend({
+  initialize: function(options) {
+    Base.prototype.initialize.call(this, options);
 
     // Responsive svg based on the following approach (embedded + padding hack)
     // http://tympanus.net/codrops/2014/08/19/making-svgs-responsive-with-css/
@@ -89,6 +83,12 @@ export default Base.extend('Compose', {
     }
 
     this.attachHoverListeners();
+  },
+
+  transform: function(data) {
+    // Save raw data for redraw
+    this.rawData(data);
+    return Base.prototype.transform.call(this, data);
   },
 
   /**
@@ -725,7 +725,7 @@ export default Base.extend('Compose', {
 });
 
 // TODO Find better place for this
-export function layered(items) {
+function layered(items) {
   if (!Array.isArray(items))
     items = Array.prototype.slice.call(arguments);
 
@@ -737,3 +737,9 @@ function findById(items, id) {
     return item.id == id;
   });
 }
+
+d3.chart().Compose = Compose;
+export {
+  Compose as default,
+  layered
+};

--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -25,8 +25,9 @@ import Component from './Component';
   @class Overlay
   @extends Component
 */
-export default Component.extend('Overlay', {
-  initialize: function() {
+var Overlay = Component.extend({
+  initialize: function(options) {
+    Component.prototype.initialize.call(this, options);
     this.base.attr('style', this.style());
   },
   skip_layout: true,
@@ -188,3 +189,6 @@ export default Component.extend('Overlay', {
 }, {
   layer_type: 'overlay'
 });
+
+d3.chart().Overlay = Overlay;
+export default Overlay;

--- a/src/charts/Bars.js
+++ b/src/charts/Bars.js
@@ -73,116 +73,112 @@ import Chart from '../Chart';
   @class Bars
   @extends Chart, Series, XYValues, LabelsXY, Hover, Transition, StandardLayer
 */
-var Bars = Chart.extend('Bars', mixin(
-  Series,
-  XYValues,
-  LabelsXY,
-  Hover,
-  Transition,
-  StandardLayer,
-  {
-    initialize: function() {
-      this.on('before:draw', function() {
-        this.offset_axis = this.getOffsetAxis();
-      }.bind(this));
 
-      // Use standard series layer for extensibility
-      // (dataBind, insert, and events defined in prototype)
-      this.standardSeriesLayer('Bars', this.base.append('g').classed('chart-bars', true));
-      this.attachLabels();
-    },
+var Bars = mixin(Chart, Series, XYValues, LabelsXY, Hover, Transition, StandardLayer).extend({
+  initialize: function(options) {
+    this._super.initialize.call(this, options);
 
-    barHeight: di(function(chart, d, i) {
-      var height = Math.abs(chart.y0() - chart.y.call(this, d, i)) - chart.barOffset();
-      return height > 0 ? height : 0;
-    }),
-    barWidth: di(function(chart) {
-      return chart.itemWidth();
-    }),
-    barX: di(function(chart, d, i) {
-      return chart.x.call(this, d, i) - chart.itemWidth() / 2;
-    }),
-    barY: di(function(chart, d, i) {
-      var y = chart.y.call(this, d, i);
-      var y0 = chart.y0();
+    this.on('before:draw', function() {
+      this.offset_axis = this.getOffsetAxis();
+    }.bind(this));
 
-      return y < y0 ? y : y0 + chart.barOffset();
-    }),
-    bar0: di(function(chart, d, i) {
-      var y0 = chart.y0();
-      var offset = chart.barOffset();
-      return chart.y.call(this, d, i) <= y0 ? y0 - offset : y0 + offset;
-    }),
-    barClass: di(function(chart, d) {
-      return 'chart-bar' + (d['class'] ? ' ' + d['class'] : '');
-    }),
+    // Use standard series layer for extensibility
+    // (dataBind, insert, and events defined in prototype)
+    this.standardSeriesLayer('Bars', this.base.append('g').classed('chart-bars', true));
+    this.attachLabels();
+  },
 
-    // Shift bars slightly to account for axis thickness
-    barOffset: function barOffset() {
-      if (this.offset_axis) {
-        var axis_thickness = parseInt(this.offset_axis.base.select('.domain').style('stroke-width')) || 0;
-        return axis_thickness / 2;
-      }
-      else {
-        return 0;
-      }
-    },
+  barHeight: di(function(chart, d, i) {
+    var height = Math.abs(chart.y0() - chart.y.call(this, d, i)) - chart.barOffset();
+    return height > 0 ? height : 0;
+  }),
+  barWidth: di(function(chart) {
+    return chart.itemWidth();
+  }),
+  barX: di(function(chart, d, i) {
+    return chart.x.call(this, d, i) - chart.itemWidth() / 2;
+  }),
+  barY: di(function(chart, d, i) {
+    var y = chart.y.call(this, d, i);
+    var y0 = chart.y0();
 
-    getOffsetAxis: function getOffsetAxis() {
-      var components = this.container && this.container.components();
-      return objectFind(components, function(component) {
-        if (component.type == 'Axis' && component.position() == 'bottom')
-          return component;
-      });
-    },
+    return y < y0 ? y : y0 + chart.barOffset();
+  }),
+  bar0: di(function(chart, d, i) {
+    var y0 = chart.y0();
+    var offset = chart.barOffset();
+    return chart.y.call(this, d, i) <= y0 ? y0 - offset : y0 + offset;
+  }),
+  barClass: di(function(chart, d) {
+    return 'chart-bar' + (d['class'] ? ' ' + d['class'] : '');
+  }),
 
-    // Override StandardLayer
-    onDataBind: function onDataBind(selection, data) {
-      return selection.selectAll('rect')
-        .data(data, this.key);
-    },
-
-    // Override StandardLayer
-    onInsert: function onInsert(selection) {
-      return selection.append('rect')
-        .on('mouseenter', this.mouseEnterPoint)
-        .on('mouseleave', this.mouseLeavePoint);
-    },
-
-    // Override StandardLayer
-    onEnter: function onEnter(selection) {
-      selection
-        .attr('y', this.bar0)
-        .attr('height', 0);
-    },
-
-    // Override StandardLayer
-    onMerge: function onMerge(selection) {
-      selection
-        .attr('class', this.barClass)
-        .attr('style', this.itemStyle)
-        .attr('x', this.barX)
-        .attr('width', this.barWidth);
-    },
-
-    // Override StandardLayer
-    onMergeTransition: function onMergeTransition(selection) {
-      this.setupTransition(selection);
-
-      selection
-        .attr('y', this.barY)
-        .attr('height', this.barHeight);
-    },
-
-    // Override StandardLayer
-    onExit: function onExit(selection) {
-      selection.remove();
+  // Shift bars slightly to account for axis thickness
+  barOffset: function barOffset() {
+    if (this.offset_axis) {
+      var axis_thickness = parseInt(this.offset_axis.base.select('.domain').style('stroke-width')) || 0;
+      return axis_thickness / 2;
     }
+    else {
+      return 0;
+    }
+  },
+
+  getOffsetAxis: function getOffsetAxis() {
+    var components = this.container && this.container.components();
+    return objectFind(components, function(component) {
+      if (component.type == 'Axis' && component.position() == 'bottom')
+        return component;
+    });
+  },
+
+  // Override StandardLayer
+  onDataBind: function onDataBind(selection, data) {
+    return selection.selectAll('rect')
+      .data(data, this.key);
+  },
+
+  // Override StandardLayer
+  onInsert: function onInsert(selection) {
+    return selection.append('rect')
+      .on('mouseenter', this.mouseEnterPoint)
+      .on('mouseleave', this.mouseLeavePoint);
+  },
+
+  // Override StandardLayer
+  onEnter: function onEnter(selection) {
+    selection
+      .attr('y', this.bar0)
+      .attr('height', 0);
+  },
+
+  // Override StandardLayer
+  onMerge: function onMerge(selection) {
+    selection
+      .attr('class', this.barClass)
+      .attr('style', this.itemStyle)
+      .attr('x', this.barX)
+      .attr('width', this.barWidth);
+  },
+
+  // Override StandardLayer
+  onMergeTransition: function onMergeTransition(selection) {
+    this.setupTransition(selection);
+
+    selection
+      .attr('y', this.barY)
+      .attr('height', this.barHeight);
+  },
+
+  // Override StandardLayer
+  onExit: function onExit(selection) {
+    selection.remove();
   }
-));
+});
 
 var bars = createHelper('Bars');
 
+d3.chart().Bars = Bars;
 export {
   Bars as default,
   bars

--- a/src/charts/HorizontalBars.js
+++ b/src/charts/HorizontalBars.js
@@ -43,7 +43,7 @@ import Bars from './Bars';
   @class HorizontalBars
   @extends Bars, XYInverted
 */
-var HorizontalBars = Bars.extend('HorizontalBars', mixin(XYInverted, {
+var HorizontalBars = mixin(Bars, XYInverted).extend({
   barX: di(function(chart, d, i) {
     var x = chart.x.call(this, d, i);
     var x0 = chart.x0();
@@ -95,10 +95,11 @@ var HorizontalBars = Bars.extend('HorizontalBars', mixin(XYInverted, {
       .attr('x', this.barX)
       .attr('width', this.barWidth);
   }
-}));
+});
 
 var horizontalBars = createHelper('HorizontalBars');
 
+d3.chart().HorizontalBars = HorizontalBars;
 export {
   HorizontalBars as default,
   horizontalBars

--- a/src/charts/HorizontalStackedBars.js
+++ b/src/charts/HorizontalStackedBars.js
@@ -40,11 +40,11 @@ import HorizontalBars from './HorizontalBars';
   @class HorizontalStackedBars
   @extends HorizontalBars
 */
-var HorizontalStackedBars = HorizontalBars.extend('HorizontalStackedBars', {
+var HorizontalStackedBars = HorizontalBars.extend({
   transform: function(data) {
     // Re-initialize bar positions each time data changes
     this.bar_positions = [];
-    return data;
+    return HorizontalBars.prototype.transform.call(this, data);
   },
 
   barWidth: di(function(chart, d, i) {
@@ -74,6 +74,7 @@ var HorizontalStackedBars = HorizontalBars.extend('HorizontalStackedBars', {
 
 var horizontalStackedBars = createHelper('HorizontalStackedBars');
 
+d3.chart().HorizontalStackedBars = HorizontalStackedBars;
 export {
   HorizontalStackedBars as default,
   horizontalStackedBars

--- a/src/charts/HoverLabels.js
+++ b/src/charts/HoverLabels.js
@@ -13,8 +13,9 @@ import Labels from './Labels';
 
   @class HoverLabels
 */
-var HoverLabels = Labels.extend('HoverLabels', mixin(Hover, {
-  initialize: function() {
+var HoverLabels = mixin(Labels, Hover).extend({
+  initialize: function(options) {
+    this._super.initialize.call(this, options);
     this.on('attach', function() {
       this.container.on('mouseenter:point', this.onMouseEnterPoint.bind(this));
       this.container.on('mouseleave:point', this.onMouseLeavePoint.bind(this));
@@ -64,10 +65,11 @@ var HoverLabels = Labels.extend('HoverLabels', mixin(Hover, {
 
     return label;
   }
-}));
+});
 
 var hoverLabels = createHelper('HoverLabels');
 
+d3.chart().HoverLabels = HoverLabels;
 export {
   HoverLabels as default,
   hoverLabels

--- a/src/charts/Lines.js
+++ b/src/charts/Lines.js
@@ -68,92 +68,86 @@ import Chart from '../Chart';
   @class Lines
   @extends Chart, Series, XY, LabelsXY, Hover, HoverPoints, Transition, StandardLayer
 */
-var Lines = Chart.extend('Lines', mixin(
-  Series,
-  XY,
-  LabelsXY,
-  Hover,
-  HoverPoints,
-  Transition,
-  StandardLayer,
-  {
-    initialize: function() {
-      this.lines = {};
+var Lines = mixin(Chart, Series, XY, LabelsXY, Hover, HoverPoints, Transition, StandardLayer).extend({
+  initialize: function(options) {
+    this._super.initialize.call(this, options);
 
-      // Use standard series layer for extensibility
-      // (dataBind, insert, and events defined in prototype)
-      this.standardSeriesLayer('Lines', this.base.append('g').classed('chart-lines', true));
+    this.lines = {};
 
-      this.attachLabels();
-    },
+    // Use standard series layer for extensibility
+    // (dataBind, insert, and events defined in prototype)
+    this.standardSeriesLayer('Lines', this.base.append('g').classed('chart-lines', true));
 
-    /**
-      Set interpolation mode for line
+    this.attachLabels();
+  },
 
-      - See: [SVG-Shapes#line_interpolate](https://github.com/mbostock/d3/wiki/SVG-Shapes#line_interpolate)
-      - Set to `null` or `'linear'` for no interpolation
+  /**
+    Set interpolation mode for line
 
-      @property interpolate
-      @type String
-      @default monotone
-    */
-    interpolate: property({
-      default_value: 'monotone'
-    }),
+    - See: [SVG-Shapes#line_interpolate](https://github.com/mbostock/d3/wiki/SVG-Shapes#line_interpolate)
+    - Set to `null` or `'linear'` for no interpolation
 
-    // Create line on insert (keyed by series/index)
-    createLine: di(function(chart, d, i, j) {
-      var key = chart.lineKey.call(this, d, i, j);
-      var line = chart.lines[key] = d3.svg.line()
-        .x(chart.x)
-        .y(chart.y);
+    @property interpolate
+    @type String
+    @default monotone
+  */
+  interpolate: property({
+    default_value: 'monotone'
+  }),
 
-      var interpolate = d.interpolate || chart.interpolate();
-      if (interpolate)
-        line.interpolate(interpolate);
-    }),
+  // Create line on insert (keyed by series/index)
+  createLine: di(function(chart, d, i, j) {
+    var key = chart.lineKey.call(this, d, i, j);
+    var line = chart.lines[key] = d3.svg.line()
+      .x(chart.x)
+      .y(chart.y);
 
-    // Get key for line (from series key or index)
-    lineKey: di(function(chart, d, i, j) {
-      var key = chart.seriesKey(chart.seriesData.call(this, d, i, j));
-      return key != null ? key : chart.seriesIndex.call(this, d, i, j);
-    }),
+    var interpolate = d.interpolate || chart.interpolate();
+    if (interpolate)
+      line.interpolate(interpolate);
+  }),
 
-    // Get data for line
-    lineData: di(function(chart, d, i, j) {
-      var key = chart.lineKey.call(this, d, i, j);
-      if (chart.lines[key])
-        return chart.lines[key](d);
-    }),
+  // Get key for line (from series key or index)
+  lineKey: di(function(chart, d, i, j) {
+    var key = chart.seriesKey(chart.seriesData.call(this, d, i, j));
+    return key != null ? key : chart.seriesIndex.call(this, d, i, j);
+  }),
 
-    // Override StandardLayer
-    onDataBind: function onDataBind(selection, data) {
-      return selection.selectAll('path')
-        .data(function(d, i, j) {
-          return [data.call(selection, d, i, j)];
-        });
-    },
+  // Get data for line
+  lineData: di(function(chart, d, i, j) {
+    var key = chart.lineKey.call(this, d, i, j);
+    if (chart.lines[key])
+      return chart.lines[key](d);
+  }),
 
-    // Override StandardLayer
-    onInsert: function onInsert(selection) {
-      return selection.append('path')
-        .classed('chart-line', true)
-        .each(this.createLine);
-    },
+  // Override StandardLayer
+  onDataBind: function onDataBind(selection, data) {
+    return selection.selectAll('path')
+      .data(function(d, i, j) {
+        return [data.call(selection, d, i, j)];
+      });
+  },
 
-    // Override StandardLayer
-    onMergeTransition: function onMergeTransition(selection) {
-      this.setupTransition(selection);
+  // Override StandardLayer
+  onInsert: function onInsert(selection) {
+    return selection.append('path')
+      .classed('chart-line', true)
+      .each(this.createLine);
+  },
 
-      selection
-        .attr('d', this.lineData)
-        .attr('style', this.itemStyle);
-    }
+  // Override StandardLayer
+  onMergeTransition: function onMergeTransition(selection) {
+    this.setupTransition(selection);
+
+    selection
+      .attr('d', this.lineData)
+      .attr('style', this.itemStyle);
   }
-));
+});
 
 var lines = createHelper('Lines');
 
+d3.chart().Lines = Lines;
 export {
   Lines as default,
   lines

--- a/src/charts/StackedBars.js
+++ b/src/charts/StackedBars.js
@@ -40,11 +40,11 @@ import Bars from './Bars';
   @class StackedBars
   @extends Bars
 */
-var StackedBars = Bars.extend('StackedBars', {
+var StackedBars = Bars.extend({
   transform: function(data) {
     // Re-initialize bar positions each time data changes
     this.bar_positions = [];
-    return data;
+    return Bars.prototype.transform.call(this, data);
   },
 
   barHeight: di(function(chart, d, i) {
@@ -74,6 +74,7 @@ var StackedBars = Bars.extend('StackedBars', {
 
 var stackedBars = createHelper('StackedBars');
 
+d3.chart().StackedBars = StackedBars;
 export {
   StackedBars as default,
   stackedBars

--- a/src/components/Axis.js
+++ b/src/components/Axis.js
@@ -72,8 +72,10 @@ import Gridlines from './Gridlines';
   @class Axis
   @extends Component, XY, Transition, StandardLayer
 */
-var Axis = Component.extend('Axis', mixin(XY, Transition, StandardLayer, {
-  initialize: function() {
+var Axis = mixin(Component, XY, Transition, StandardLayer).extend({
+  initialize: function(options) {
+    this._super.initialize.call(this, options);
+
     // Store previous values for transitioning
     this.previous = {};
 
@@ -136,9 +138,9 @@ var Axis = Component.extend('Axis', mixin(XY, Transition, StandardLayer, {
       });
     }
 
-    function createGridlines(axis, options) {
+    function createGridlines(axis, gridline_options) {
       var base = axis.base.append('g').attr('class', 'chart-axis-gridlines');
-      return new Gridlines(base, options);
+      return new Gridlines(base, gridline_options);
     }
   },
 
@@ -499,13 +501,14 @@ var Axis = Component.extend('Axis', mixin(XY, Transition, StandardLayer, {
       height: d3.max(overhangs.height)
     };
   }
-}), {
+}, {
   layer_type: 'chart',
   z_index: 60
 });
 
 var axis = createHelper('Axis');
 
+d3.chart().Axis = Axis;
 export {
   Axis as default,
   axis

--- a/src/components/AxisTitle.js
+++ b/src/components/AxisTitle.js
@@ -11,8 +11,9 @@ import Title from './Title';
   @class AxisTitle
   @extends Title
 */
-var AxisTitle = Title.extend('AxisTitle', {
-  initialize: function() {
+var AxisTitle = Title.extend({
+  initialize: function(options) {
+    Title.prototype.initialize.call(this, options);
     this.base.select('.chart-text')
       .classed('chart-title', false)
       .classed('chart-axis-title', true);
@@ -53,6 +54,7 @@ function axisTitle(id, options) {
   return textOptions(id, options, {type: 'AxisTitle'});
 }
 
+d3.chart().AxisTitle = AxisTitle;
 export {
   AxisTitle as default,
   axisTitle

--- a/src/components/Gridlines.js
+++ b/src/components/Gridlines.js
@@ -61,8 +61,10 @@ import Component from '../Component';
   ```
   @class Gridlines
 */
-var Gridlines = Component.extend('Gridlines', mixin(XY, Transition, StandardLayer, {
-  initialize: function() {
+var Gridlines = mixin(Component, XY, Transition, StandardLayer).extend({
+  initialize: function(options) {
+    this._super.initialize.call(this, options);
+
     // Proxy attach to parent for width/height
     var parent = this.options().parent;
     if (parent) {
@@ -200,13 +202,14 @@ var Gridlines = Component.extend('Gridlines', mixin(XY, Transition, StandardLaye
   },
 
   skip_layout: true
-}), {
+}, {
   layer_type: 'chart',
   z_index: 55
 });
 
 var gridlines = createHelper('Gridlines');
 
+d3.chart().Gridlines = Gridlines;
 export {
   Gridlines as default,
   gridlines

--- a/src/components/InsetLegend.js
+++ b/src/components/InsetLegend.js
@@ -12,8 +12,9 @@ import Legend from './Legend';
   @class InsetLegend
   @extends Legend
 */
-var InsetLegend = Legend.extend('InsetLegend', {
-  initialize: function() {
+var InsetLegend = Legend.extend({
+  initialize: function(options) {
+    Legend.prototype.initialize.call(this, options);
     this.on('draw', function() {
       // Position legend on draw
       // (Need actual width/height for relative_to)
@@ -75,6 +76,7 @@ var InsetLegend = Legend.extend('InsetLegend', {
 
 var insetLegend = createHelper('InsetLegend');
 
+d3.chart().InsetLegend = InsetLegend;
 export {
   InsetLegend as default,
   insetLegend

--- a/src/components/Legend.js
+++ b/src/components/Legend.js
@@ -93,8 +93,9 @@ var default_legend_margins = {top: 8, right: 8, bottom: 8, left: 8};
   @class Legend
   @extends Component, StandardLayer
 */
-var Legend = Component.extend('Legend', mixin(StandardLayer, {
-  initialize: function() {
+var Legend = mixin(Component, StandardLayer).extend({
+  initialize: function(options) {
+    this._super.initialize.call(this, options);
     this.legend_base = this.base.append('g').classed('chart-legend', true);
     this.standardLayer('Legend', this.legend_base);
   },
@@ -328,7 +329,7 @@ var Legend = Component.extend('Legend', mixin(StandardLayer, {
       i: i
     };
   }
-}), {
+}, {
   z_index: 200,
   swatches: {
     'default': function(chart) {
@@ -393,6 +394,7 @@ Legend.registerSwatch(['Bars', 'StackedBars', 'HorizontalBars', 'HorizontalStack
 
 var legend = createHelper('Legend');
 
+d3.chart().Legend = Legend;
 export {
   Legend as default,
   legend

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -57,8 +57,10 @@ import Component from '../Component';
   @class Text
   @extends Component, StandardLayer
 */
-var Text = Component.extend('Text', mixin(StandardLayer, {
-  initialize: function() {
+var Text = mixin(Component, StandardLayer).extend({
+  initialize: function(options) {
+    this._super.initialize.call(this, options);
+
     // Use standard layer for extensibility
     this.standardLayer('Text', this.base.append('g').classed('chart-text', true));
   },
@@ -177,7 +179,7 @@ var Text = Component.extend('Text', mixin(StandardLayer, {
 
     return translation + ' ' + rotation;
   }
-}), {
+}, {
   z_index: 70
 });
 
@@ -196,6 +198,7 @@ function text(id, options) {
   return textOptions(id, options, {type: 'Text'});
 }
 
+d3.chart().Text = Text;
 export {
   Text as default,
   text,

--- a/src/components/Title.js
+++ b/src/components/Title.js
@@ -10,8 +10,9 @@ import Text, { textOptions } from './Text';
   @class Title
   @extends Text
 */
-var Title = Text.extend('Title', {
-  initialize: function() {
+var Title = Text.extend({
+  initialize: function(options) {
+    Text.prototype.initialize.call(this, options);
     this.base.select('.chart-text').classed('chart-title', true);
   },
 
@@ -67,6 +68,7 @@ function title(id, options) {
   return textOptions(id, options, {type: 'Title'});
 }
 
+d3.chart().Title = Title;
 export {
   Title as default,
   title

--- a/src/mixins/hover.js
+++ b/src/mixins/hover.js
@@ -210,6 +210,9 @@ function getPoints(chart, data) {
 }
 
 function getClosestPoints(points, position, tolerance) {
+  if (!points)
+    return [];
+
   return compact(points.map(function(series) {
     function setDistance(point) {
       point.distance = getDistance(point.meta, position);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,8 @@
 // Many utils inlined from Underscore.js
 // (c) 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
 
-var slice = Array.prototype.slice;
-var toString = Object.prototype.toString;
+export var slice = Array.prototype.slice;
+export var toString = Object.prototype.toString;
 
 function _extend(target, extensions, undefined_only) {
   for (var i = 0, length = extensions.length; i < length; i++) {
@@ -119,6 +119,22 @@ export function uniq(arr) {
   return result;
 }
 
+export function inherits(Child, Parent) {
+  Child.prototype = Object.create(Parent.prototype, {
+    constructor: {
+      value: Child,
+      enumerable: false,
+      writeable: true,
+      configurable: true
+    }
+  });
+
+  if (Object.setPrototypeOf)
+    Object.setPrototypeOf(Child, Parent);
+  else
+    Child.__proto__ = Parent; //eslint-disable-line no-proto
+}
+
 // If value isn't `undefined`, return `value`, otherwise use `default_value`
 //
 // @method valueOrDefault
@@ -130,6 +146,8 @@ export function valueOrDefault(value, default_value) {
 }
 
 var utils = {
+  slice: slice,
+  toString: toString,
   contains: contains,
   compact: compact,
   difference: difference,
@@ -148,6 +166,7 @@ var utils = {
   objectFind: objectFind,
   pluck: pluck,
   uniq: uniq,
+  inherits: inherits,
   valueOrDefault: valueOrDefault
 };
 export default utils;


### PR DESCRIPTION
- Base explicitly inherits d3.chart() with modifications: no implicit
  initialize/transform cascade and extend more closely matches ES6 class
  extends
- `mixin` updated for compatibility with ES6 classes
- Charts/Components need to be explicitly registered with d3.chart
