### PR TITLE
Enable dynamic label position

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -212,6 +212,7 @@
             ];
           })
           .duration(1000)
+          .margins({bottom: 30})
           .width(600)
           .height(400);
 

--- a/example/js/data.js
+++ b/example/js/data.js
@@ -78,7 +78,7 @@
 
     'chart-3': [
       {key: 'a', name: 'A', values: [10000, 20000]},
-      {key: 'b', name: 'B', values: [20000, 25000]}
+      {key: 'b', name: 'B', values: [-20000, -25000]}
     ],
 
     // Specs


### PR DESCRIPTION
Allows `top|bottom` label position as well as "di" function for additional customization.

`(a)|(b)`: `a` for `y-value >= 0` and `b` otherwise, where `a` and `b` are `top`, `right`, `bottom`, or `left`

`function(d, i) { return d.x >= 0 ? 'right' : 'left'; }`
